### PR TITLE
feat: add url redirect on markdown link if no slug provided

### DIFF
--- a/proto_dmd_app/views.py
+++ b/proto_dmd_app/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, redirect, get_object_or_404
 from .models import MarkdownContent
 
 def index_view(request):
@@ -8,6 +8,9 @@ def index_view(request):
         "proto_dmd_app/index_template.html",
         context=context
     )
+
+def redirect_index_view(request):
+    return redirect('/')
 
 def markdown_content_view(request, slug):
     markdown_content = get_object_or_404(MarkdownContent, slug=slug)

--- a/proto_dmd_project/urls.py
+++ b/proto_dmd_project/urls.py
@@ -1,13 +1,13 @@
 from django.contrib import admin
 from django.urls import path
 from proto_dmd_app.views import markdown_content_view
+from proto_dmd_app.views import redirect_index_view
 from proto_dmd_app.views import index_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", index_view, name="index"),
-    path(
-        "mc/<slug:slug>/", markdown_content_view, name="markdown-content"
-    ),
+    path("mc/", redirect_index_view, name="redirect-to-index"),
+    path("mc/<slug:slug>/", markdown_content_view, name="markdown-content"),
 ]
 


### PR DESCRIPTION
When the markdown link is inputted (`/mc/`) it expects a slug to represent the endpoint for the desired markdown content model. For example: `/mc/<slug-name>`. However if no slug is inputted, the application will simply redirect to the index. 